### PR TITLE
Create fetch-inspired landing page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,488 @@
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: #f4f2ff;
+  color: #1a1330;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.hero {
+  background: linear-gradient(135deg, #3d16ff 0%, #ff4ee0 100%);
+  color: #ffffff;
+  padding: 2.5rem clamp(2rem, 6vw, 5rem) 5.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 10% -20% auto auto;
+  width: clamp(18rem, 28vw, 30rem);
+  height: clamp(18rem, 28vw, 30rem);
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.4), transparent 60%);
+  filter: blur(0.4rem);
+  pointer-events: none;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  position: relative;
+  z-index: 1;
+}
+
+.logo {
+  font-weight: 800;
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  letter-spacing: -0.02em;
+  text-transform: lowercase;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  padding: 0;
+  margin: 0;
+  font-weight: 500;
+}
+
+.nav-links a {
+  opacity: 0.85;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  opacity: 1;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.75);
+  outline-offset: 3px;
+}
+
+.btn-light {
+  background: rgba(255, 255, 255, 0.16);
+  color: #ffffff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(4px);
+}
+
+.btn-light:hover {
+  background: rgba(255, 255, 255, 0.28);
+  transform: translateY(-1px);
+}
+
+.btn-primary {
+  background: #ffffff;
+  color: #2a0f81;
+  box-shadow: 0 12px 32px rgba(17, 0, 98, 0.25);
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 40px rgba(17, 0, 98, 0.28);
+}
+
+.btn-outline {
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  color: #ffffff;
+  background: transparent;
+}
+
+.btn-outline:hover {
+  background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.hero-content {
+  margin-top: clamp(3rem, 7vw, 5rem);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2rem, 6vw, 4.5rem);
+  position: relative;
+  z-index: 1;
+}
+
+.hero-text h1 {
+  font-size: clamp(2.4rem, 5vw, 3.8rem);
+  margin: 0.8rem 0 1.5rem;
+  letter-spacing: -0.02em;
+}
+
+.hero-text p {
+  margin: 0 0 2rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 36rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(255, 255, 255, 0.16);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-metrics {
+  margin: 2.5rem 0 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, auto));
+  gap: clamp(1.5rem, 5vw, 3rem);
+}
+
+.hero-metrics div {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.hero-metrics dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.hero-metrics dd {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.hero-visual {
+  display: flex;
+  justify-content: center;
+}
+
+.phone-shell {
+  background: rgba(255, 255, 255, 0.2);
+  padding: 1.2rem;
+  border-radius: 2rem;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 24px 60px rgba(14, 0, 89, 0.35);
+}
+
+.phone-screen {
+  width: min(20rem, 70vw);
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 1.4rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: #1a1330;
+}
+
+.screen-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.screen-balance-label {
+  font-size: 0.85rem;
+  color: #6f6498;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.screen-balance {
+  font-weight: 700;
+  font-size: 2rem;
+}
+
+.screen-receipts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.screen-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  background: #f4f2ff;
+}
+
+.screen-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.screen-card p {
+  margin: 0.35rem 0 0;
+  color: #7c75a2;
+  font-size: 0.85rem;
+}
+
+.screen-card span {
+  font-weight: 600;
+  color: #5632ff;
+}
+
+.screen-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-top: 0.5rem;
+}
+
+.screen-footer button {
+  background: linear-gradient(135deg, #5632ff 0%, #ff4ee0 100%);
+  color: #ffffff;
+  border: none;
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+main {
+  flex: 1;
+  background: linear-gradient(180deg, #f4f2ff 0%, #ffffff 60%);
+}
+
+.section {
+  padding: clamp(4rem, 8vw, 6rem) clamp(2rem, 8vw, 6.5rem);
+}
+
+.section h2 {
+  margin: 0 0 1.25rem;
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  letter-spacing: -0.01em;
+}
+
+.section-lede {
+  margin: 0 auto 3rem;
+  max-width: 45rem;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: #4f4775;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14.5rem, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 16px 36px rgba(45, 31, 128, 0.12);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.card p {
+  margin: 0;
+  color: #514876;
+  line-height: 1.6;
+}
+
+.steps {
+  background: radial-gradient(circle at top left, rgba(86, 50, 255, 0.1), transparent 55%);
+}
+
+.section-heading {
+  max-width: 38rem;
+  margin-bottom: 3rem;
+}
+
+.steps-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.step-card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2.1rem 2rem;
+  position: relative;
+  display: grid;
+  gap: 0.85rem;
+  box-shadow: 0 18px 40px rgba(39, 24, 110, 0.12);
+}
+
+.step-number {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #7b73a8;
+}
+
+.step-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.step-card p {
+  margin: 0;
+  color: #4f4775;
+  line-height: 1.6;
+}
+
+.partners {
+  text-align: center;
+}
+
+.partner-logos {
+  margin-top: 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(1.2rem, 4vw, 2.5rem);
+  font-weight: 600;
+  color: #372a82;
+}
+
+.partner-logos span {
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  background: #ece8ff;
+  min-width: 8rem;
+}
+
+.highlight {
+  display: flex;
+  justify-content: center;
+}
+
+.highlight-card {
+  background: linear-gradient(135deg, #2a0f81 0%, #4225ff 60%, #ff4ee0 100%);
+  color: #ffffff;
+  padding: clamp(3rem, 8vw, 4.5rem);
+  border-radius: 2rem;
+  text-align: center;
+  max-width: 54rem;
+  box-shadow: 0 24px 60px rgba(32, 13, 93, 0.3);
+}
+
+.highlight-card p {
+  margin: 1rem auto 2.5rem;
+  max-width: 36rem;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.footer {
+  padding: 2rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #756fa0;
+  background: #f0ecff;
+}
+
+@media (max-width: 960px) {
+  .nav-links {
+    display: none;
+  }
+
+  .hero-content {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-text {
+    text-align: center;
+  }
+
+  .hero-text p {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .hero-metrics {
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    justify-items: center;
+  }
+
+  .hero-visual {
+    margin-top: 2rem;
+  }
+
+  .cta-group {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 2rem 1.5rem 4rem;
+  }
+
+  .section {
+    padding: 3.5rem 1.5rem;
+  }
+
+  .partner-logos span {
+    min-width: 6.5rem;
+  }
+
+  .btn {
+    width: 100%;
+  }
+
+  .cta-group {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,219 @@
+import './App.css'
+
+const featureCards = [
+  {
+    title: 'Snap any receipt',
+    description:
+      'Upload a photo or forward an e-receipt from anywhere you shop. Fetch finds every eligible offer for you.',
+  },
+  {
+    title: 'Earn on every shop',
+    description:
+      'Points stack fast with weekly bonuses and partner offers from groceries, retailers, restaurants, and more.',
+  },
+  {
+    title: 'Redeem in seconds',
+    description:
+      'Cash in for digital gift cards, charitable donations, or sweepstakes entries the moment you hit your goal.',
+  },
+]
+
+const steps = [
+  {
+    number: '01',
+    title: 'Download the app',
+    copy:
+      'Create an account for free and join millions of shoppers already earning rewards on the everyday things they buy.',
+  },
+  {
+    number: '02',
+    title: 'Scan your receipts',
+    copy:
+      'Snap a photo of any paper receipt or forward your online receipts to fetch@receipts.com to keep points flowing.',
+  },
+  {
+    number: '03',
+    title: 'Collect points automatically',
+    copy:
+      'We apply eligible offers instantly, so you always know exactly how many points you earned for each purchase.',
+  },
+  {
+    number: '04',
+    title: 'Redeem what you love',
+    copy:
+      'Turn points into gift cards from brands you actually use—Target, Amazon, Starbucks, and hundreds more.',
+  },
+]
+
+const partnerLogos = [
+  'Target',
+  'Amazon',
+  'Starbucks',
+  'Ulta Beauty',
+  'DoorDash',
+  'Instacart',
+]
+
+const receiptActivity = [
+  { retailer: 'Target', points: '+1,200 pts', time: '2m ago' },
+  { retailer: 'Whole Foods', points: '+950 pts', time: '1h ago' },
+  { retailer: 'Amazon', points: '+700 pts', time: 'Today' },
+  { retailer: 'Starbucks', points: '+350 pts', time: 'Yesterday' },
+]
+
 function App() {
   return (
-    <main
-      style={{
-        alignItems: 'center',
-        display: 'flex',
-        fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-        fontSize: '4rem',
-        fontWeight: 700,
-        justifyContent: 'center',
-        margin: 0,
-        minHeight: '100vh',
-        textTransform: 'uppercase',
-      }}
-    >
-      Hello World
-    </main>
+    <div className="app" id="top">
+      <header className="hero">
+        <nav className="nav" aria-label="Primary">
+          <a href="#top" className="logo" aria-label="Fetch home">
+            fetch
+          </a>
+          <ul className="nav-links">
+            <li>
+              <a href="#how-it-works">How it works</a>
+            </li>
+            <li>
+              <a href="#rewards">Rewards</a>
+            </li>
+            <li>
+              <a href="#partners">Partners</a>
+            </li>
+          </ul>
+          <a className="btn btn-light" href="#download">
+            Get the app
+          </a>
+        </nav>
+        <div className="hero-content">
+          <div className="hero-text">
+            <span className="pill">Rewards in seconds</span>
+            <h1>Scan receipts. Earn rewards. Repeat.</h1>
+            <p>
+              Stop leaving money on the table. Fetch turns every grocery run, coffee stop, and online order into points you can
+              redeem for the things you love.
+            </p>
+            <div className="cta-group">
+              <a className="btn btn-primary" href="#download">
+                Download on iOS
+              </a>
+              <a className="btn btn-outline" href="#download">
+                Get it on Google Play
+              </a>
+            </div>
+            <dl className="hero-metrics">
+              <div>
+                <dt>Active shoppers</dt>
+                <dd>13M+</dd>
+              </div>
+              <div>
+                <dt>Receipts scanned monthly</dt>
+                <dd>1B</dd>
+              </div>
+              <div>
+                <dt>Gift cards redeemed</dt>
+                <dd>100M+</dd>
+              </div>
+            </dl>
+          </div>
+          <div className="hero-visual" aria-hidden>
+            <div className="phone-shell">
+              <div className="phone-screen">
+                <header className="screen-header">
+                  <span className="screen-balance-label">Points balance</span>
+                  <span className="screen-balance">24,380</span>
+                </header>
+                <div className="screen-receipts">
+                  {receiptActivity.map((receipt) => (
+                    <article className="screen-card" key={receipt.retailer}>
+                      <div>
+                        <h3>{receipt.retailer}</h3>
+                        <p>{receipt.time}</p>
+                      </div>
+                      <span>{receipt.points}</span>
+                    </article>
+                  ))}
+                </div>
+                <footer className="screen-footer">
+                  <span>Redeem points</span>
+                  <button type="button">Shop rewards</button>
+                </footer>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section className="section features" id="how-it-works">
+          <h2>Turn everyday purchases into free rewards</h2>
+          <p className="section-lede">
+            Fetch automatically finds the best offers for you. Just snap a receipt and we take care of the rest.
+          </p>
+          <div className="card-grid">
+            {featureCards.map((feature) => (
+              <article className="card" key={feature.title}>
+                <h3>{feature.title}</h3>
+                <p>{feature.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="section steps" id="rewards">
+          <div className="section-heading">
+            <h2>Getting rewarded is simple</h2>
+            <p className="section-lede">
+              From download to redemption, Fetch is designed to keep you motivated. No clipping coupons or linking accounts
+              required.
+            </p>
+          </div>
+          <div className="steps-grid">
+            {steps.map((step) => (
+              <article className="step-card" key={step.number}>
+                <span className="step-number">{step.number}</span>
+                <h3>{step.title}</h3>
+                <p>{step.copy}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="section partners" id="partners">
+          <h2>Brands you love partner with Fetch</h2>
+          <p className="section-lede">
+            Earn bonus points faster with exclusive offers from national retailers, delivery services, and your neighborhood
+            favorites.
+          </p>
+          <div className="partner-logos">
+            {partnerLogos.map((partner) => (
+              <span key={partner}>{partner}</span>
+            ))}
+          </div>
+        </section>
+
+        <section className="section highlight" id="download">
+          <div className="highlight-card">
+            <h2>Ready to start earning in minutes?</h2>
+            <p>
+              Download Fetch, scan your first receipt, and watch the points add up. It is the fastest way to reward yourself for
+              the shopping you already do.
+            </p>
+            <div className="cta-group">
+              <a className="btn btn-light" href="#top">
+                Download for iOS
+              </a>
+              <a className="btn btn-outline" href="#top">
+                Download for Android
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer className="footer">
+        <p>© {new Date().getFullYear()} Fetch Holdings, Inc. All rights reserved.</p>
+      </footer>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- replace the placeholder Hello World screen with a Fetch-inspired marketing layout including hero, feature, steps, and partner sections
- add a stylized simulated app preview and calls-to-action to mirror the Fetch app experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e4d794e8832c83c66e244c4bbdbd