### PR TITLE
Refine hero phone mock to mirror mobile app

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -201,85 +201,390 @@ a {
   border-radius: 2rem;
   backdrop-filter: blur(6px);
   box-shadow: 0 24px 60px rgba(14, 0, 89, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  position: relative;
+}
+
+.phone-shell::after {
+  content: '';
+  position: absolute;
+  bottom: 0.65rem;
+  left: 50%;
+  width: 4.2rem;
+  height: 0.28rem;
+  background: rgba(26, 19, 48, 0.2);
+  border-radius: 999px;
+  transform: translateX(-50%);
 }
 
 .phone-screen {
-  width: min(20rem, 70vw);
-  background: #ffffff;
-  border-radius: 1.5rem;
-  padding: 1.4rem 1.2rem;
+  width: min(21rem, 72vw);
+  background: #f8f6ff;
+  border-radius: 1.75rem;
+  padding: 1rem 1.1rem 0.9rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
   color: #1a1330;
+  position: relative;
+  overflow: hidden;
 }
 
-.screen-header {
+.status-bar {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
+  font-size: 0.75rem;
+  color: #7468a4;
+  padding: 0 0.25rem;
+}
+
+.status-time {
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.status-icons {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.icon-signal,
+.icon-wifi,
+.icon-battery {
+  display: inline-flex;
+  position: relative;
+  width: 1.1rem;
+  height: 0.65rem;
+  border-radius: 0.15rem;
+  background: rgba(116, 104, 164, 0.2);
+}
+
+.icon-signal::after,
+.icon-wifi::after,
+.icon-battery::after {
+  content: '';
+  position: absolute;
+  inset: 0.1rem;
+  border-radius: inherit;
+  background: #5b4d99;
+}
+
+.icon-wifi {
+  height: 0.7rem;
+  border-radius: 999px 999px 0 0;
+  overflow: hidden;
+}
+
+.icon-wifi::after {
+  inset: 0.18rem 0.22rem auto;
+  height: 0.2rem;
+  background: #5b4d99;
+  border-radius: 999px 999px 0 0;
+}
+
+.icon-battery {
+  width: 1.4rem;
+}
+
+.icon-battery::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: -0.22rem;
+  width: 0.18rem;
+  height: 0.32rem;
+  background: #5b4d99;
+  border-radius: 0.08rem;
+  transform: translateY(-50%);
+}
+
+.icon-battery::after {
+  inset: 0.12rem;
+  background: transparent;
+  border: 1px solid #5b4d99;
+}
+
+.battery-level {
+  position: absolute;
+  inset: 0.18rem 0.22rem 0.18rem 0.18rem;
+  background: #5b4d99;
+  border-radius: 0.08rem;
+}
+
+.screen-hero {
+  background: linear-gradient(135deg, #4b2aff 0%, #ff77d1 100%);
+  color: #ffffff;
+  border-radius: 1.45rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1.1rem;
+  box-shadow: 0 18px 36px rgba(71, 30, 200, 0.28);
+}
+
+.screen-hero-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.avatar {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
+  position: relative;
+}
+
+.avatar::after {
+  content: '';
+  position: absolute;
+  inset: 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.screen-hero-text {
+  display: grid;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.screen-hero-label {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.screen-hero-text strong {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.screen-settings {
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.18);
+  position: relative;
+}
+
+.screen-settings::after {
+  content: '';
+  position: absolute;
+  inset: 0.65rem;
+  border-radius: 0.35rem;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+}
+
+.screen-balance-block {
+  display: grid;
+  gap: 0.35rem;
 }
 
 .screen-balance-label {
-  font-size: 0.85rem;
-  color: #6f6498;
-  text-transform: uppercase;
+  font-size: 0.8rem;
   letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .screen-balance {
+  font-size: 2.4rem;
   font-weight: 700;
-  font-size: 2rem;
+  letter-spacing: -0.01em;
 }
 
-.screen-receipts {
+.screen-hero-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.screen-action-primary,
+.screen-action-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.9rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.screen-action-primary {
+  background: #ffffff;
+  color: #4827ff;
+  box-shadow: 0 12px 28px rgba(40, 0, 150, 0.3);
+}
+
+.screen-action-secondary {
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.screen-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.summary-card {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 0.9rem;
+  padding: 0.75rem 0.65rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.summary-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.summary-value {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.screen-section {
+  background: #ffffff;
+  border-radius: 1.35rem;
+  padding: 1.15rem 1rem 1.05rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 18px 40px rgba(29, 20, 90, 0.12);
+}
+
+.screen-section-header {
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.screen-section-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.screen-view-all {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #4b2aff;
+}
+
+.screen-list {
+  display: grid;
   gap: 0.75rem;
 }
 
 .screen-card {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  padding: 0.9rem 1rem;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
   border-radius: 1rem;
-  background: #f4f2ff;
+  background: #f2efff;
 }
 
-.screen-card h3 {
+.screen-card-icon {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, rgba(75, 42, 255, 0.85) 0%, rgba(255, 119, 209, 0.85) 100%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.screen-card h4 {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 1rem;
 }
 
 .screen-card p {
-  margin: 0.35rem 0 0;
+  margin: 0.3rem 0 0;
   color: #7c75a2;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
 }
 
-.screen-card span {
+.screen-card-points {
   font-weight: 600;
-  color: #5632ff;
+  color: #4b2aff;
 }
 
-.screen-footer {
+.screen-nav {
+  margin-top: auto;
+  background: #ffffff;
+  border-radius: 1.35rem;
+  padding: 0.6rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-weight: 600;
-  font-size: 0.95rem;
-  margin-top: 0.5rem;
+  gap: 0.45rem;
+  box-shadow: 0 16px 36px rgba(24, 16, 88, 0.18);
 }
 
-.screen-footer button {
-  background: linear-gradient(135deg, #5632ff 0%, #ff4ee0 100%);
-  color: #ffffff;
-  border: none;
-  padding: 0.5rem 1.1rem;
-  border-radius: 999px;
+.screen-nav-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  flex: 1;
+  font-size: 0.75rem;
   font-weight: 600;
-  cursor: pointer;
+  color: #867cac;
+  padding: 0.45rem 0.35rem;
+  border-radius: 0.9rem;
+}
+
+.screen-nav-item.is-active {
+  color: #4b2aff;
+  background: rgba(75, 42, 255, 0.12);
+}
+
+.nav-icon {
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 0.65rem;
+  background: rgba(75, 42, 255, 0.12);
+  position: relative;
+}
+
+.nav-icon::after {
+  content: '';
+  position: absolute;
+  inset: 0.4rem;
+  border-radius: 0.3rem;
+  background: currentColor;
+}
+
+.nav-icon-scan::after {
+  border: 2px solid currentColor;
+  background: transparent;
+  border-radius: 0.35rem;
+}
+
+.nav-icon-rewards::after {
+  border-radius: 999px;
+  background: linear-gradient(135deg, currentColor 0%, rgba(75, 42, 255, 0.3) 100%);
+}
+
+.nav-icon-profile::after {
+  border-radius: 999px;
+  background: currentColor;
+  transform: translateY(10%);
 }
 
 main {
@@ -478,6 +783,14 @@ main {
   .cta-group {
     flex-direction: column;
     gap: 0.75rem;
+  }
+
+  .screen-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .screen-nav {
+    gap: 0.25rem;
   }
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,6 +61,12 @@ const receiptActivity = [
   { retailer: 'Starbucks', points: '+350 pts', time: 'Yesterday' },
 ]
 
+const quickStats = [
+  { label: 'Receipt streak', value: '5 days' },
+  { label: 'Rewards ready', value: '$15' },
+  { label: 'Team bonus', value: '420 pts' },
+]
+
 function App() {
   return (
     <div className="app" id="top">
@@ -115,28 +121,81 @@ function App() {
               </div>
             </dl>
           </div>
-          <div className="hero-visual" aria-hidden>
+          <div className="hero-visual" aria-hidden="true">
             <div className="phone-shell">
               <div className="phone-screen">
-                <header className="screen-header">
-                  <span className="screen-balance-label">Points balance</span>
-                  <span className="screen-balance">24,380</span>
-                </header>
-                <div className="screen-receipts">
-                  {receiptActivity.map((receipt) => (
-                    <article className="screen-card" key={receipt.retailer}>
-                      <div>
-                        <h3>{receipt.retailer}</h3>
-                        <p>{receipt.time}</p>
-                      </div>
-                      <span>{receipt.points}</span>
-                    </article>
-                  ))}
+                <div className="status-bar">
+                  <span className="status-time">9:41</span>
+                  <div className="status-icons">
+                    <span className="icon-signal" />
+                    <span className="icon-wifi" />
+                    <span className="icon-battery">
+                      <span className="battery-level" />
+                    </span>
+                  </div>
                 </div>
-                <footer className="screen-footer">
-                  <span>Redeem points</span>
-                  <button type="button">Shop rewards</button>
-                </footer>
+                <section className="screen-hero" aria-label="Rewards overview">
+                  <div className="screen-hero-top">
+                    <span className="avatar" />
+                    <div className="screen-hero-text">
+                      <span className="screen-hero-label">Rewards</span>
+                      <strong>Good morning, Maya</strong>
+                    </div>
+                    <span className="screen-settings" />
+                  </div>
+                  <div className="screen-balance-block">
+                    <span className="screen-balance-label">Points balance</span>
+                    <span className="screen-balance">24,380</span>
+                  </div>
+                  <div className="screen-hero-actions">
+                    <span className="screen-action-primary">Scan</span>
+                    <span className="screen-action-secondary">Redeem</span>
+                  </div>
+                  <div className="screen-summary">
+                    {quickStats.map((stat) => (
+                      <div className="summary-card" key={stat.label}>
+                        <span className="summary-label">{stat.label}</span>
+                        <span className="summary-value">{stat.value}</span>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+                <section className="screen-section" aria-label="Recent activity">
+                  <header className="screen-section-header">
+                    <h3>Recent activity</h3>
+                    <span className="screen-view-all">View all</span>
+                  </header>
+                  <div className="screen-list">
+                    {receiptActivity.map((receipt) => (
+                      <article className="screen-card" key={receipt.retailer}>
+                        <span className="screen-card-icon">{receipt.retailer.charAt(0)}</span>
+                        <div>
+                          <h4>{receipt.retailer}</h4>
+                          <p>{receipt.time}</p>
+                        </div>
+                        <span className="screen-card-points">{receipt.points}</span>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+                <nav className="screen-nav" aria-label="App navigation">
+                  <div className="screen-nav-item is-active">
+                    <span className="nav-icon nav-icon-home" />
+                    <span>Home</span>
+                  </div>
+                  <div className="screen-nav-item">
+                    <span className="nav-icon nav-icon-scan" />
+                    <span>Scan</span>
+                  </div>
+                  <div className="screen-nav-item">
+                    <span className="nav-icon nav-icon-rewards" />
+                    <span>Rewards</span>
+                  </div>
+                  <div className="screen-nav-item">
+                    <span className="nav-icon nav-icon-profile" />
+                    <span>Profile</span>
+                  </div>
+                </nav>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Rebuilt the hero phone mockup to include a status bar, gradient rewards header, quick stats, and bottom navigation that matches the mobile app experience.
- Overhauled the accompanying styles to detail the phone shell, activity cards, nav icons, and responsive behavior for the updated layout.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2e455f7a0832c9f6aea4eef87dae3